### PR TITLE
Fix compiler.watch() parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ webpack: {
 	watch: true, // use webpacks watcher
 	// You need to keep the grunt process alive
 
+	watchOptions: {
+		aggregateTimeout: 500,
+		poll: true
+	},
+	// Use this when you need to fallback to poll based watching
+
 	keepalive: true, // don't finish the grunt task
 	// Use this in combination with the watch option
 

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -120,7 +120,7 @@ module.exports = function(grunt) {
 		}
 
 		if (watch) {
-			compiler.watch(options.watchDelay || 200, handler);
+			compiler.watch(options.watchOptions || {}, handler);
 		} else {
 			compiler.run(handler);
 		}


### PR DESCRIPTION
According to https://webpack.github.io/docs/node.js-api.html,
watch API is compiler.watch(watchOptions, handler) where
watchOptions is a object with aggregateTimeout and poll
properties, not an integer.
